### PR TITLE
add options, bump up v3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 *.swp
 *.swo
 *.swn
+
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Google Translate API for Node
 =====================
 
-A Node.js module for working with the [Google Cloud Translation API](https://cloud.google.com/translate/docs/). 
+A Node.js module for working with the [Google Cloud Translation API](https://cloud.google.com/translate/docs/).
 
 Automatically handles bulk translations that exceed the Google Translation API query limit.
 
@@ -17,9 +17,9 @@ Usage overview
 ----------
 
 Require module and pass in your API Google project API key after enabling the API service. Note: This module currently doesn't support oauth authentication.
-  
+
     var googleTranslate = require('google-translate')(apiKey);
-    
+
 String translation:
 
     googleTranslate.translate('My name is Brandon', 'es', function(err, translation) {
@@ -38,14 +38,33 @@ Language detection:
 
 **Callbacks**: All methods take a callback as their last parameter. Upon method completion, callbacks are passed an error if exists (otherwise null), followed by a response object or array: `callback(err, data)`.
 
-**Bulk translations**:  Passing an array of strings greater than 5k characters will be result in multiple concurrent asynchronous calls. Once all calls are completed, the response will be parsed, merged, and  passed to the callback. The default maximum concurrent requests is 10. You can override this value by passing in a new limit when you pass in your API key: `require('google-translate')(apiKey, concurrentLimit)`
+**Bulk translations**:  Passing an array of strings greater than 5k characters will be result in multiple concurrent asynchronous calls. Once all calls are completed, the response will be parsed, merged, and  passed to the callback. The default maximum concurrent requests is 10. You can override this value by passing in a new limit when you pass in your API key: `require('google-translate')(apiKey, { concurrent: 20 })`
+
+## options
+Now available options are `concurrentLimit` and `requestOptions`. Refer follow example:
+```
+var fs = require('fs');
+var apiKey = 'AXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXY';
+var options = {
+  concurrentLimit: 20,
+  requestOptions: {
+    proxy: 'http://123.123.123.123:8080',
+    ca: fs.readFileSync('/usr/share/ca-certificates/company/company.crt'),
+  },
+};
+var googleTranslate = require('google-translate')(apiKey, options);
+googleTranslate.translate('My name is Brandon', 'es', function(err, translation) {
+  console.log(translation.translatedText);
+  // =>  Mi nombre es Brandon
+});
+```
 
 ### Translate
 
 Translate one or more strings.
 
     googleTranslate.translate(strings, source, target, callback)
-    
+
 * **strings**: Required. Can be a string or an array of strings
 * **source**: Optional. Google will autodetect the source locale if not specified. [Available languages](https://developers.google.com/translate/v2/using_rest#target)
 * **target**:  Required. Language to translate to. [Available languages](https://developers.google.com/translate/v2/using_rest#target)
@@ -64,16 +83,16 @@ Translate one or more strings.
       console.log(translations);
       // =>  [{ translatedText: 'Hallo', originalText: 'Hello' }, ...]
     });
-  
+
 ### Detect language
 
 Detect language of string or each string in an array.
 
     googleTranslate.detectLanguage(strings, callback)
-    
+
 * **strings**: Required. Can be a string or an array of strings
 * **callback**:  Required.
- 
+
 *Example*: Detect language from a string
 
     googleTranslate.detectLanguage('Hello', function(err, detection){
@@ -95,7 +114,7 @@ Retrieve all languages supported by the Google Translate API.
 
 
     googleTranslate.getSupportedLanguages(target, callback)
-    
+
 * **target**: Optional. If specified, response will include the name of the language translated to the specified target language
 * **callback**:  Required.
 
@@ -105,7 +124,7 @@ Retrieve all languages supported by the Google Translate API.
       console.log(languageCodes);
       // => ['af', 'ar', 'be', 'bg', 'ca', 'cs', ...]
     });
-    
+
 *Example*: Get all supported language codes with language names in German
 
     googleTranslate.getSupportedLanguages('de', function(err, languageCodes) {
@@ -113,7 +132,7 @@ Retrieve all languages supported by the Google Translate API.
       // => [{ language: "en", name: "Englisch" }, ...]
     });
 
-  
+
 # Contribute
 
 Forks and pull requests welcome!

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Language detection:
 
 **Callbacks**: All methods take a callback as their last parameter. Upon method completion, callbacks are passed an error if exists (otherwise null), followed by a response object or array: `callback(err, data)`.
 
-**Bulk translations**:  Passing an array of strings greater than 5k characters will be result in multiple concurrent asynchronous calls. Once all calls are completed, the response will be parsed, merged, and  passed to the callback. The default maximum concurrent requests is 10. You can override this value by passing in a new limit when you pass in your API key: `require('google-translate')(apiKey, { concurrent: 20 })`
+**Bulk translations**:  Passing an array of strings greater than 5k characters will be result in multiple concurrent asynchronous calls. Once all calls are completed, the response will be parsed, merged, and  passed to the callback. The default maximum concurrent requests is 10. You can override this value by passing in a new limit when you pass in your API key: `require('google-translate')(apiKey, { concurrentLimit: 20 })`
 
 ## options
 Now available options are `concurrentLimit` and `requestOptions`. Refer follow example:

--- a/lib/main.js
+++ b/lib/main.js
@@ -155,7 +155,8 @@ var splitArraysForGoogle = function(arr, result) {
 //   PUBLIC API
 ////
 
-module.exports = function(apiKey, options={}) {
+module.exports = function(apiKey, options) {
+  options = options || {}
   var requestOptions = options.requestOptions || {}
   if( _.keys( requestOptions ).length > 0 ) {
     request = request.defaults( requestOptions );

--- a/lib/main.js
+++ b/lib/main.js
@@ -155,10 +155,14 @@ var splitArraysForGoogle = function(arr, result) {
 //   PUBLIC API
 ////
 
-module.exports = function(apiKey, newConcurrentLimit) {
+module.exports = function(apiKey, options={}) {
+  var requestOptions = options.requestOptions || {}
+  if( _.keys( requestOptions ).length > 0 ) {
+    request = request.defaults( requestOptions );
+  }
 
   // Set new concurrent limit for async calls if specified
-  concurrentLimit = newConcurrentLimit || concurrentLimit;
+  concurrentLimit = options.concurrentLimit || concurrentLimit;
 
   var get = getRequestWithApi(apiKey),
       post = postRequestWithApi(apiKey),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Brandon Paton <brandon@localizejs.com>",
   "name": "google-translate",
   "description": "Google Translate API for Node.js",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "homepage": "https://github.com/Localize/node-google-translate",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Brandon Paton <brandon@localizejs.com>",
   "name": "google-translate",
   "description": "Google Translate API for Node.js",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "homepage": "https://github.com/Localize/node-google-translate",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To use `request` library's options, I added options to `google-translate`.
In options, we can use `requestOptions`.

This changes is not backwards compatible, so I bumped a minor version up.